### PR TITLE
Don't calculate column every time, rather offer methods for that

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -79,7 +79,7 @@ fn bench_slice_columns_only(b: &mut Bencher) {
     let input = LocatedSpan::new(text.as_str());
 
     b.iter(|| {
-        input.slice(500..501);
+        input.slice(500..501).get_column_utf8().unwrap();
     });
 }
 
@@ -91,6 +91,6 @@ fn bench_slice_columns_only_for_ascii_text(b: &mut Bencher) {
 
     assert!(text.is_ascii());
     b.iter(|| {
-        input.slice(500..501);
+        input.slice(500..501).get_column();
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@
 //!     assert_eq!(output.unwrap().1.position, Span {
 //!         offset: 14,
 //!         line: 2,
-//!         column: 1,
 //!         fragment: ""
 //!     });
 //! }
@@ -50,10 +49,7 @@ mod tests;
 use std::iter::Enumerate;
 use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
 use std::slice::Iter;
-use std::str::CharIndices;
-use std::str::Chars;
-use std::str::{FromStr};
-
+use std::str::{CharIndices, Chars, FromStr, Utf8Error};
 
 use memchr::Memchr;
 use nom::{
@@ -75,22 +71,18 @@ pub struct LocatedSpan<T> {
     /// parser. It starts at line 1.
     pub line: u32,
 
-    /// The column number of the fragment relatively to the input of the
-    /// parser. It starts at column 0.
-    // FIXME allow starting at 1
-    pub column: u32,
-
     /// The fragment that is spanned.
     /// The fragment represents a part of the input of the parser.
     pub fragment: T,
 }
 
-impl<T> LocatedSpan<T> {
+impl<T: AsBytes> LocatedSpan<T> {
 
-    /// Create a span for a particular input with default `offset`,
-    /// `line`, and `column` values.
+    /// Create a span for a particular input with default `offset` and
+    /// `line` values. You can compute the column through the `get_column` or `get_column_utf8`
+    /// methods.
     ///
-    /// `offset` starts at 0, `line` starts at 1, and `column` starts at 0.
+    /// `offset` starts at 0, `line` starts at 1, and `column` starts at 1.
     ///
     /// # Example of use
     ///
@@ -101,19 +93,87 @@ impl<T> LocatedSpan<T> {
     /// # fn main() {
     /// let span = LocatedSpan::new(b"foobar");
     ///
-    /// assert_eq!(span.offset,     0);
-    /// assert_eq!(span.line,       1);
-    /// assert_eq!(span.column,     0);
-    /// assert_eq!(span.fragment,   &b"foobar"[..]);
+    /// assert_eq!(span.offset,         0);
+    /// assert_eq!(span.line,           1);
+    /// assert_eq!(span.get_column(),   1);
+    /// assert_eq!(span.fragment,       &b"foobar"[..]);
     /// # }
     /// ```
     pub fn new(program: T) -> LocatedSpan<T> {
          LocatedSpan {
              line: 1,
-             column: 0,
              offset: 0,
              fragment: program
          }
+    }
+
+    fn get_columns_and_bytes_before(&self) -> (usize, &[u8]) {
+        let self_bytes = self.fragment.as_bytes();
+        let self_ptr = self_bytes.as_ptr();
+        let before_self = unsafe {
+            assert!(self.offset <= isize::max_value() as usize, "offset is too big");
+            let orig_input_ptr = self_ptr.offset(-(self.offset as isize));
+            std::slice::from_raw_parts(orig_input_ptr, self.offset)
+        };
+
+        let column = match memchr::memrchr(b'\n', before_self) {
+            None => self.offset + 1,
+            Some(pos) => {
+                self.offset - pos
+            }
+        };
+
+        (column, &before_self[self.offset - (column - 1)..])
+    }
+
+    /// Return the column index, assuming 1 byte = 1 column.
+    ///
+    /// Use it for ascii text, or use get_column_utf8 for UTF8.
+    ///
+    /// # Example of use
+    /// ```
+    ///
+    /// # extern crate nom_locate;
+    /// # extern crate nom;
+    /// # use nom_locate::LocatedSpan;
+    /// # use nom::Slice;
+    /// #
+    /// # fn main() {
+    /// let span = LocatedSpan::new("foobar");
+    ///
+    /// assert_eq!(span.slice(3..).get_column(), 4);
+    /// # }
+    /// ```
+    pub fn get_column(&self) -> usize {
+        self.get_columns_and_bytes_before().0
+    }
+
+    /// Return the column index for a UTF8 text.
+    ///
+    /// **Caution**: that's a rather slow method. Prefer using
+    /// `get_column()` if your input is an ASCII-only text.
+    ///
+    /// # Example of use
+    /// ```
+    ///
+    /// # extern crate nom_locate;
+    /// # extern crate nom;
+    /// # use nom_locate::LocatedSpan;
+    /// # use nom::{Slice, FindSubstring};
+    /// #
+    /// # fn main() {
+    /// let span = LocatedSpan::new("メカジキ");
+    /// let indexOf3dKanji = span.find_substring("ジ").unwrap();
+    ///
+    /// assert_eq!(span.slice(indexOf3dKanji..).get_column(), 7);
+    /// assert_eq!(span.slice(indexOf3dKanji..).get_column_utf8(), Ok(3));
+    /// # }
+    /// ```
+    pub fn get_column_utf8(&self) -> Result<usize, Utf8Error> {
+        let before_self = self.get_columns_and_bytes_before().1;
+        Ok(std::str::from_utf8(before_self)?
+            .chars()
+            .count() + 1)
     }
 }
 
@@ -255,7 +315,6 @@ macro_rules! slice_range_impl {
                 let consumed_len = self.fragment.offset(&next_fragment);
                 if consumed_len == 0 {
                     return LocatedSpan {
-                        column: self.column,
                         line: self.line,
                         offset: self.offset,
                         fragment: next_fragment
@@ -266,20 +325,11 @@ macro_rules! slice_range_impl {
                 let next_offset = self.offset + consumed_len;
 
                 let consumed_as_bytes = consumed.as_bytes();
-                let mut iter = Memchr::new(b'\n', consumed_as_bytes);
-                let (number_of_lines, next_column) = match iter.next_back() {
-                    None => (0, self.column + consumed.count_utf8() as u32),
-                    Some(position) => {
-                        let next_column = self.fragment.slice(position..consumed_len)
-                            .count_utf8() as u32;
-
-                        (iter.count() as u32 + 1, next_column)
-                    }
-                };
+                let iter = Memchr::new(b'\n', consumed_as_bytes);
+                let number_of_lines = iter.count() as u32;
                 let next_line = self.line + number_of_lines;
 
                 LocatedSpan {
-                    column: next_column,
                     line: next_line,
                     offset: next_offset,
                     fragment: next_fragment
@@ -413,37 +463,6 @@ macro_rules! offset_impl {
 
 offset_impl! {&'a str}
 offset_impl! {&'a [u8]}
-
-/// Trait to count utf8 chars
-pub trait CountUtf8Chars {
-    /// Return the number of UTF-8 chars.
-    ///
-    /// # Example of use
-    /// ````
-    /// # extern crate nom_locate;
-    /// use nom_locate::CountUtf8Chars;
-    ///
-    /// # fn main() {
-    /// assert_eq!("un œuf éclot".len(), 14); // That's not the number of characters
-    /// assert_eq!("un œuf éclot".count_utf8(), 12);
-    /// # }
-    /// ````
-    fn count_utf8(&self) -> usize;
-}
-
-impl<'a> CountUtf8Chars for &'a str {
-    fn count_utf8(&self) -> usize {
-        self.chars().count()
-    }
-}
-
-impl<'a> CountUtf8Chars for &'a [u8] {
-    fn count_utf8(&self) -> usize {
-        std::str::from_utf8(self)
-            .expect("The slice should contain UTF-8 chars only")
-            .count_utf8()
-    }
-}
 
 impl<T: ToString> ToString for LocatedSpan<T> {
     fn to_string(&self) -> String {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,6 @@ fn it_should_call_new_for_u8_successfully() {
     let output = BytesSpan {
         offset : 0,
         line  : 1,
-        column: 0,
         fragment : input
     };
 
@@ -26,7 +25,6 @@ fn it_should_call_new_for_str_successfully() {
     let output = StrSpan {
         offset : 0,
         line  : 1,
-        column: 0,
         fragment : input
     };
 
@@ -39,19 +37,16 @@ fn it_should_slice_for_str() {
     assert_eq!(str_slice.slice(1..), StrSpan {
         offset: 1,
         line: 1,
-        column: 1,
         fragment: "oobar"
     });
     assert_eq!(str_slice.slice(1..3), StrSpan {
         offset: 1,
         line: 1,
-        column: 1,
         fragment: "oo"
     });
     assert_eq!(str_slice.slice(..3), StrSpan {
         offset: 0,
         line: 1,
-        column: 0,
         fragment: "foo"
     });
     assert_eq!(str_slice.slice(..), str_slice);
@@ -63,33 +58,46 @@ fn it_should_slice_for_u8() {
     assert_eq!(bytes_slice.slice(1..), BytesSpan {
         offset: 1,
         line: 1,
-        column: 1,
         fragment: b"oobar"
     });
     assert_eq!(bytes_slice.slice(1..3), BytesSpan {
         offset: 1,
         line: 1,
-        column: 1,
         fragment: b"oo"
     });
     assert_eq!(bytes_slice.slice(..3), BytesSpan {
         offset: 0,
         line: 1,
-        column: 0,
         fragment: b"foo"
     });
     assert_eq!(bytes_slice.slice(..), bytes_slice);
 }
 
 #[test]
+fn it_should_calculate_columns() {
+    let input = StrSpan::new("foo
+        bar");
+
+
+    let bar_idx = input.find_substring("bar").unwrap();
+    assert_eq!(input.slice(bar_idx..).get_column(), 9);
+}
+
+#[test]
 fn it_should_calculate_columns_accurately_with_non_ascii_chars() {
     let s = StrSpan::new("メカジキ");
-    assert_eq!(s.slice(6..), LocatedSpan {
-        line: 1,
-        column: 2,
-        offset: 6,
-        fragment: "ジキ"
-    });
+    assert_eq!(s.slice(6..).get_column_utf8(), Ok(3));
+}
+
+#[test]
+#[should_panic(expected = "offset is too big")]
+fn it_should_panic_when_getting_column_if_offset_is_too_big() {
+    let s = StrSpan {
+        offset: usize::max_value(),
+        fragment: "",
+        line: 1
+    };
+    s.get_column();
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,11 +2,11 @@
 extern crate nom;
 extern crate nom_locate;
 
-use std::ops::Range;
+use std::ops::{Range, RangeFull};
 use std::fmt::Debug;
 use nom_locate::LocatedSpan;
 use std::cmp;
-use nom::{IResult, ErrorKind, FindSubstring, InputLength, Slice};
+use nom::{IResult, ErrorKind, FindSubstring, InputLength, Slice, AsBytes};
 
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
@@ -39,63 +39,64 @@ named!(simple_parser_u8< BytesSpan, Vec<BytesSpan> >, do_parse!(
 
 struct Position {
     line: u32,
-    column: u32,
+    column: usize,
     offset: usize,
     fragment_len: usize
 }
 
-fn test_str_fragments<'a, F, T>(parser: F, input: T, fragments: Vec<Position>)
+fn test_str_fragments<'a, F, T>(parser: F, input: T, positions: Vec<Position>)
     where F: Fn(LocatedSpan<T>) -> IResult<LocatedSpan<T>, Vec<LocatedSpan<T>>>,
-          T: InputLength + Slice<Range<usize>> + Debug + PartialEq {
+          T: InputLength + Slice<Range<usize>> + Slice<RangeFull> + Debug + PartialEq + AsBytes {
 
-    let expected: Vec<LocatedSpan<T>> = fragments.iter().map(|pos: &Position| {
-        LocatedSpan {
-            column: pos.column,
-            line: pos.line,
-            offset: pos.offset,
-            fragment: input.slice(pos.offset..cmp::min(pos.offset + pos.fragment_len, input.input_len()))
-        }
-    }).collect();
-    let res = parser(LocatedSpan::new(input));
+    let res = parser(LocatedSpan::new(input.slice(..)));
     assert!(res.is_done(), "the parser should run successfully");
     let (remaining, output) = res.unwrap();
     assert!(remaining.fragment.input_len() == 0, "no input should remain");
-    assert_eq!(output, expected);
+    assert_eq!(output.len(), positions.len());
+    for (output_item, pos) in output.iter().zip(positions.iter()) {
+        let expected_item = LocatedSpan {
+            line: pos.line,
+            offset: pos.offset,
+            fragment: input.slice(pos.offset..cmp::min(pos.offset + pos.fragment_len, input.input_len()))
+        };
+        assert_eq!(output_item, &expected_item);
+        assert_eq!(output_item.get_column_utf8(), Ok(pos.column), "columns should be equal");
+    }
 }
 
 #[test]
 fn it_locates_str_fragments() {
     test_str_fragments(simple_parser_str, "foobarbaz", vec![
-        Position { line: 1, column: 0, offset: 0, fragment_len: 3 },
-        Position { line: 1, column: 3, offset: 3, fragment_len: 3 },
-        Position { line: 1, column: 6, offset: 6, fragment_len: 3 },
-        Position { line: 1, column: 9, offset: 9, fragment_len: 3 }
+        Position { line: 1, column: 1, offset: 0, fragment_len: 3 },
+        Position { line: 1, column: 4, offset: 3, fragment_len: 3 },
+        Position { line: 1, column: 7, offset: 6, fragment_len: 3 },
+        Position { line: 1, column: 10, offset: 9, fragment_len: 3 }
     ]);
     test_str_fragments(simple_parser_str, " foo
         bar
             baz", vec![
-        Position { line: 1, column: 1,  offset: 1,  fragment_len: 3 },
-        Position { line: 2, column: 8,  offset: 13, fragment_len: 3 },
-        Position { line: 3, column: 12, offset: 29, fragment_len: 3 },
-        Position { line: 3, column: 15, offset: 32, fragment_len: 3 }
+        Position { line: 1, column: 2,  offset: 1,  fragment_len: 3 },
+        Position { line: 2, column: 9,  offset: 13, fragment_len: 3 },
+        Position { line: 3, column: 13, offset: 29, fragment_len: 3 },
+        Position { line: 3, column: 16, offset: 32, fragment_len: 3 }
     ]);
 }
 
 #[test]
 fn it_locates_u8_fragments() {
     test_str_fragments(simple_parser_u8, &b"foobarbaz"[..], vec![
-        Position { line: 1, column: 0, offset: 0, fragment_len: 3 },
-        Position { line: 1, column: 3, offset: 3, fragment_len: 3 },
-        Position { line: 1, column: 6, offset: 6, fragment_len: 3 },
-        Position { line: 1, column: 9, offset: 9, fragment_len: 3 }
+        Position { line: 1, column: 1, offset: 0, fragment_len: 3 },
+        Position { line: 1, column: 4, offset: 3, fragment_len: 3 },
+        Position { line: 1, column: 7, offset: 6, fragment_len: 3 },
+        Position { line: 1, column: 10, offset: 9, fragment_len: 3 }
     ]);
     test_str_fragments(simple_parser_u8, &b" foo
         bar
             baz"[..], vec![
-        Position { line: 1, column: 1,  offset: 1,  fragment_len: 3 },
-        Position { line: 2, column: 8,  offset: 13, fragment_len: 3 },
-        Position { line: 3, column: 12, offset: 29, fragment_len: 3 },
-        Position { line: 3, column: 15, offset: 32, fragment_len: 3 }
+        Position { line: 1, column: 2,  offset: 1,  fragment_len: 3 },
+        Position { line: 2, column: 9,  offset: 13, fragment_len: 3 },
+        Position { line: 3, column: 13, offset: 29, fragment_len: 3 },
+        Position { line: 3, column: 16, offset: 32, fragment_len: 3 }
     ]);
 }
 
@@ -137,10 +138,10 @@ pour le malheur et l’enseignement des hommes,
 la peste réveillerait ses rats et les enverrait mourir dans une cité heureuse.";
 
     let expected = vec![
-        Position { line: 5,  column: 4,  offset: 233, fragment_len: 10 },
-        Position { line: 6,  column: 3,  offset: 295, fragment_len: 3  },
-        Position { line: 7,  column: 28, offset: 386, fragment_len: 3  },
-        Position { line: 11, column: 0,  offset: 573, fragment_len: 8  }
+        Position { line: 5,  column: 5,  offset: 233, fragment_len: 10 },
+        Position { line: 6,  column: 4,  offset: 295, fragment_len: 3  },
+        Position { line: 7,  column: 29, offset: 386, fragment_len: 3  },
+        Position { line: 11, column: 1,  offset: 573, fragment_len: 8  }
     ];
 
     test_str_fragments(plague, input, expected);


### PR DESCRIPTION
Calculating column is slow, especially for utf8 columns.

This PR removes column computation every slice and rather offers two methods instead for this: `LocatedSpan::get_column()` and `LocatedSpan::get_column_utf8()`.

That's a good compromise:
 - users who don't care about that won't be impacted by performance degradation (fixes #3)
 - users who are sure to have ASCII text (whether they previously checked using `str::is_ascii` or because they assume it) would call `get_column()`
 - users who expect UTF8 chars in their program would rather call `get_column_utf8()`