### PR TITLE
Inital port to nom 4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,16 @@ license = "MIT"
 name = "nom_locate"
 readme = "README.md"
 repository = "https://github.com/fflorent/nom_locate"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 [badges.travis-ci]
 repository = "fflorent/nom_locate"
 
 [features]
 avx-accel = ["bytecount/avx-accel"]
 simd-accel = ["bytecount/simd-accel"]
+verbose-errors = ["nom/verbose-errors"]
 
 [dependencies]
 bytecount = "^0.3"
 memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
-nom = "4.0.0-beta1"
+nom = "4.0.0-beta2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,15 @@ license = "MIT"
 name = "nom_locate"
 readme = "README.md"
 repository = "https://github.com/fflorent/nom_locate"
-version = "0.1.1"
+version = "0.3.0-beta.1"
 [badges.travis-ci]
 repository = "fflorent/nom_locate"
 
+[features]
+avx-accel = ["bytecount/avx-accel"]
+simd-accel = ["bytecount/simd-accel"]
+
 [dependencies]
-memchr = "1.0.1"
-nom = "^3.2"
+bytecount = "^0.3"
+memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
+nom = "4.0.0-beta1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "nom_locate"
 readme = "README.md"
 repository = "https://github.com/fflorent/nom_locate"
-version = "0.1.0"
+version = "0.1.1"
 [badges.travis-ci]
 repository = "fflorent/nom_locate"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,18 @@
 [package]
-name = "nom_locate"
-version = "0.1.0"
 authors = ["Florent FAYOLLE <florent.fayolle69@gmail.com>"]
-license = "MIT"
+categories = ["parsing"]
 description = "A special input type for nom to locate tokens"
-
 documentation = "https://docs.rs/nom_locate/"
 homepage = "https://github.com/fflorent/nom_locate"
-repository = "https://github.com/fflorent/nom_locate"
-readme = "README.md"
-
 keywords = ["nom"]
-categories = ["parsing"]
-
-[badges]
-travis-ci = { repository = "fflorent/nom_locate" }
-
+license = "MIT"
+name = "nom_locate"
+readme = "README.md"
+repository = "https://github.com/fflorent/nom_locate"
+version = "0.1.0"
+[badges.travis-ci]
+repository = "fflorent/nom_locate"
 
 [dependencies]
-nom = "^3.1"
 memchr = "1.0.1"
-
+nom = "^3.2"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -11,8 +11,7 @@ use nom::Slice;
 use test::Bencher;
 
 // Lorem ipsum is boring. Let's quote Camus' Plague.
-const TEXT: &str =
-"Écoutant, en effet, les cris d’allégresse qui montaient de la ville,
+const TEXT: &str = "Écoutant, en effet, les cris d’allégresse qui montaient de la ville,
 Rieux se souvenait que cette allégresse était toujours menacée.
 Car il savait ce que cette foule en joie ignorait,
 et qu’on peut lire dans les livres,
@@ -24,8 +23,7 @@ et que, peut-être, le jour viendrait où,
 pour le malheur et l’enseignement des hommes,
 la peste réveillerait ses rats et les enverrait mourir dans une cité heureuse.";
 
-const TEXT_ASCII: &str =
-"Ecoutant, en effet, les cris d'allegresse qui montaient de la ville,
+const TEXT_ASCII: &str = "Ecoutant, en effet, les cris d'allegresse qui montaient de la ville,
 Rieux se souvenait que cette allegresse etait toujours menacee.
 Car il savait ce que cette foule en joie ignorait,
 et qu'on peut lire dans les livres,
@@ -79,12 +77,13 @@ fn bench_slice_columns_only(b: &mut Bencher) {
     let input = LocatedSpan::new(text.as_str());
 
     b.iter(|| {
-        input.slice(500..501).get_column_utf8().unwrap();
+        input.slice(500..501).get_utf8_column();
     });
 }
 
 #[bench]
 fn bench_slice_columns_only_for_ascii_text(b: &mut Bencher) {
+    #[allow(unused)]
     use std::ascii::AsciiExt;
     let text = TEXT_ASCII.replace("\n", "");
     let input = LocatedSpan::new(text.as_str());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,39 +544,14 @@ where
     }
 }
 
-/// Implement nom::Offset for a specific fragment type.
-///
-/// # Parameters
-/// * `$fragment_type` - The LocatedSpan's `fragment` type
-///
-/// # Example of use
-///
-/// NB: This example is an extract from the nom_locate source code.
-///
-/// ````ignore
-/// #[macro_use]
-/// extern crate nom_locate;
-///
-/// impl_offset! {&'a str}
-/// impl_offset! {&'a [u8]}
-/// ````
-#[macro_export]
-macro_rules! impl_offset {
-    ( $fragment_type:ty ) => {
-        #[cfg(not(feature = "core"))]
-        impl<'a> Offset for LocatedSpan<$fragment_type> {
-            fn offset(&self, second: &LocatedSpan<$fragment_type>) -> usize {
-                    let fst = self.fragment.as_ptr();
-                    let snd = second.fragment.as_ptr();
+impl<T> Offset for LocatedSpan<T> {
+    fn offset(&self, second: &Self) -> usize {
+        let fst = self.offset;
+        let snd = second.offset;
 
-                    snd as usize - fst as usize
-            }
-        }
+        snd - fst
     }
 }
-
-impl_offset! {&'a str}
-impl_offset! {&'a [u8]}
 
 impl<T: ToString> ToString for LocatedSpan<T> {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! The source code is available on [Github](https://github.com/fflorent/nom_locate)
 //!
+//! ## Features
+//!
+//! This crate exposes two cargo feature flags, `avx-accel` and `simd-accel`.
+//! These correspond to the features exposed by [bytecount](https://github.com/llogiq/bytecount).
+//! Compile with SSE support (available on most modern x86_64 processors) using `simd-accel`, or
+//! with AVX support (which likely requires compiling for the native target CPU) with both.
+//!
 //! ## How to use it
 //! The explanations are given in the [README](https://github.com/fflorent/nom_locate/blob/master/README.md) of the Github repository. You may also consult the [FAQ](https://github.com/fflorent/nom_locate/blob/master/FAQ.md).
 //!
@@ -44,22 +51,23 @@
 //!     assert_eq!(position.get_column(), 2);
 //! }
 //! ````
-extern crate nom;
+extern crate bytecount;
 extern crate memchr;
+extern crate nom;
 
 #[cfg(test)]
 mod tests;
 
-use std::iter::Enumerate;
-use std::ops::{Range, RangeTo, RangeFrom, RangeFull};
+use std::iter::{Enumerate, Map};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use std::slice::Iter;
-use std::str::{CharIndices, Chars, FromStr, Utf8Error};
+use std::str::{CharIndices, Chars, FromStr};
 
 use memchr::Memchr;
-use nom::{
-    InputLength, Slice, InputIter, Compare, CompareResult,
-    Offset, FindToken, FindSubstring, ParseTo, AsBytes
-};
+use nom::{AsBytes, Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength,
+          Offset, ParseTo, Slice, InputTake, AtEof};
+use nom::types::{CompleteByteSlice, CompleteStr};
+use bytecount::{naive_num_chars, num_chars};
 
 /// A LocatedSpan is a set of meta information about the location of a token.
 ///
@@ -81,9 +89,8 @@ pub struct LocatedSpan<T> {
 }
 
 impl<T: AsBytes> LocatedSpan<T> {
-
     /// Create a span for a particular input with default `offset` and
-    /// `line` values. You can compute the column through the `get_column` or `get_column_utf8`
+    /// `line` values. You can compute the column through the `get_column` or `get_utf8_column`
     /// methods.
     ///
     /// `offset` starts at 0, `line` starts at 1, and `column` starts at 1.
@@ -104,27 +111,28 @@ impl<T: AsBytes> LocatedSpan<T> {
     /// # }
     /// ```
     pub fn new(program: T) -> LocatedSpan<T> {
-         LocatedSpan {
-             line: 1,
-             offset: 0,
-             fragment: program
-         }
+        LocatedSpan {
+            line: 1,
+            offset: 0,
+            fragment: program,
+        }
     }
 
     fn get_columns_and_bytes_before(&self) -> (usize, &[u8]) {
         let self_bytes = self.fragment.as_bytes();
         let self_ptr = self_bytes.as_ptr();
         let before_self = unsafe {
-            assert!(self.offset <= isize::max_value() as usize, "offset is too big");
+            assert!(
+                self.offset <= isize::max_value() as usize,
+                "offset is too big"
+            );
             let orig_input_ptr = self_ptr.offset(-(self.offset as isize));
             std::slice::from_raw_parts(orig_input_ptr, self.offset)
         };
 
         let column = match memchr::memrchr(b'\n', before_self) {
             None => self.offset + 1,
-            Some(pos) => {
-                self.offset - pos
-            }
+            Some(pos) => self.offset - pos,
         };
 
         (column, &before_self[self.offset - (column - 1)..])
@@ -132,7 +140,7 @@ impl<T: AsBytes> LocatedSpan<T> {
 
     /// Return the column index, assuming 1 byte = 1 column.
     ///
-    /// Use it for ascii text, or use get_column_utf8 for UTF8.
+    /// Use it for ascii text, or use get_utf8_column for UTF8.
     ///
     /// # Example of use
     /// ```
@@ -152,10 +160,13 @@ impl<T: AsBytes> LocatedSpan<T> {
         self.get_columns_and_bytes_before().0
     }
 
-    /// Return the column index for a UTF8 text.
+    /// Return the column index for UTF8 text. Return value is unspecified for non-utf8 text.
     ///
-    /// **Caution**: that's a rather slow method. Prefer using
-    /// `get_column()` if your input is an ASCII-only text.
+    /// This version uses bytecount's hyper algorithm to count characters. This is much faster
+    /// for long lines, but is non-negligibly slower for short slices (below around 100 bytes).
+    /// This is also sped up significantly more depending on architecture and enabling the simd
+    /// feature gates. If you expect primarily short lines, you may get a noticeable speedup in
+    /// parsing by using `naive_get_utf8_column` instead. Benchmark your specific use case!
     ///
     /// # Example of use
     /// ```
@@ -170,20 +181,62 @@ impl<T: AsBytes> LocatedSpan<T> {
     /// let indexOf3dKanji = span.find_substring("ジ").unwrap();
     ///
     /// assert_eq!(span.slice(indexOf3dKanji..).get_column(), 7);
-    /// assert_eq!(span.slice(indexOf3dKanji..).get_column_utf8(), Ok(3));
+    /// assert_eq!(span.slice(indexOf3dKanji..).get_utf8_column(), 3);
     /// # }
     /// ```
-    pub fn get_column_utf8(&self) -> Result<usize, Utf8Error> {
+    pub fn get_utf8_column(&self) -> usize {
         let before_self = self.get_columns_and_bytes_before().1;
-        Ok(std::str::from_utf8(before_self)?
-            .chars()
-            .count() + 1)
+        num_chars(before_self)+ 1
+    }
+
+    /// Return the column index for UTF8 text. Return value is unspecified for non-utf8 text.
+    ///
+    /// A simpler implementation of `get_utf8_column` that may be faster on shorter lines.
+    /// If benchmarking shows that this is faster, you can use it instead of `get_utf8_column`.
+    /// Prefer defaulting to `get_utf8_column` unless this legitimately is a performance bottleneck.
+    ///
+    /// # Example of use
+    /// ```
+    ///
+    /// # extern crate nom_locate;
+    /// # extern crate nom;
+    /// # use nom_locate::LocatedSpan;
+    /// # use nom::{Slice, FindSubstring};
+    /// #
+    /// # fn main() {
+    /// let span = LocatedSpan::new("メカジキ");
+    /// let indexOf3dKanji = span.find_substring("ジ").unwrap();
+    ///
+    /// assert_eq!(span.slice(indexOf3dKanji..).get_column(), 7);
+    /// assert_eq!(span.slice(indexOf3dKanji..).naive_get_utf8_column(), 3);
+    /// # }
+    /// ```
+    pub fn naive_get_utf8_column(&self) -> usize {
+        let before_self = self.get_columns_and_bytes_before().1;
+        naive_num_chars(before_self) + 1
     }
 }
 
 impl<T: InputLength> InputLength for LocatedSpan<T> {
     fn input_len(&self) -> usize {
         self.fragment.input_len()
+    }
+}
+
+impl<T: AtEof> AtEof for LocatedSpan<T> {
+    fn at_eof(&self) -> bool {
+        self.fragment.at_eof()
+    }
+}
+
+// TODO: Think about why this trait is here
+impl<T> InputTake for LocatedSpan<T> where Self: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> {
+    fn take(&self, count: usize) -> Self {
+        self.slice(..count)
+    }
+
+    fn take_split(&self, count: usize) -> (Self, Self) {
+        (self.slice(count..), self.slice(..count))
     }
 }
 
@@ -238,9 +291,21 @@ macro_rules! impl_input_iter {
 }
 
 impl_input_iter!(&'a str, char, char, CharIndices<'a>, Chars<'a>);
-impl_input_iter!(&'a [u8], &'a u8, u8, Enumerate<Iter<'a, Self::RawItem>>,
-                 Iter<'a, Self::RawItem>);
-
+impl_input_iter!(
+    &'a [u8],
+    u8,
+    u8,
+    Enumerate<Self::IterElem>,
+    Map<Iter<'a, Self::Item>, fn(&u8) -> u8>
+);
+impl_input_iter!(CompleteStr<'a>, char, char, CharIndices<'a>, Chars<'a>);
+impl_input_iter!(
+    CompleteByteSlice<'a>,
+    u8,
+    u8,
+    Enumerate<Self::IterElem>,
+    Map<Iter<'a, Self::Item>, fn(&u8) -> u8>
+);
 
 /// Implement nom::Compare for a specific fragment type.
 ///
@@ -277,8 +342,36 @@ macro_rules! impl_compare {
 }
 
 impl_compare!(&'b str, &'a str);
+impl_compare!(CompleteStr<'b>, &'a str);
 impl_compare!(&'b [u8], &'a [u8]);
+impl_compare!(CompleteByteSlice<'b>, &'a [u8]);
 impl_compare!(&'b [u8], &'a str);
+impl_compare!(CompleteByteSlice<'b>, &'a str);
+
+impl<A: Compare<B>, B> Compare<LocatedSpan<B>> for LocatedSpan<A> {
+    #[inline(always)]
+    fn compare(&self, t: LocatedSpan<B>) -> CompareResult {
+        self.fragment.compare(t.fragment)
+    }
+
+    #[inline(always)]
+    fn compare_no_case(&self, t: LocatedSpan<B>) -> CompareResult {
+        self.fragment.compare_no_case(t.fragment)
+    }
+}
+
+// TODO(future): replace impl_compare! with below default specialization?
+// default impl<A: Compare<B>, B> Compare<B> for LocatedSpan<A> {
+//     #[inline(always)]
+//     fn compare(&self, t: B) -> CompareResult {
+//         self.fragment.compare(t)
+//     }
+//
+//     #[inline(always)]
+//     fn compare_no_case(&self, t: B) -> CompareResult {
+//         self.fragment.compare_no_case(t)
+//     }
+// }
 
 /// Implement nom::Slice for a specific fragment type and range type.
 ///
@@ -376,52 +469,19 @@ macro_rules! impl_slice_ranges {
 
 impl_slice_ranges! {&'a str}
 impl_slice_ranges! {&'a [u8]}
+impl_slice_ranges! {CompleteStr<'a>}
+impl_slice_ranges! {CompleteByteSlice<'a>}
 
-/// Implement nom::FindToken for a specific token type.
-///
-/// # Parameters
-/// * `$for_type` - The token type.
-/// * `$fragment_type` - The LocatedSpan's `fragment` type which has to be searchable.
-///
-/// # Example of use
-///
-/// NB: This example is an extract from the nom_locate source code.
-///
-/// ````ignore
-/// #[macro_use]
-/// extern crate nom_locate;
-///
-/// impl_find_token! { char, &'a str}
-///
-/// impl_find_token! { u8, &'a str}
-/// impl_find_token! { &'b u8, &'a str}
-///
-/// impl_find_token! { u8, &'a [u8]}
-/// impl_find_token! { &'b u8, &'a [u8]}
-/// ````
-#[macro_export]
-macro_rules! impl_find_token {
-    ( $for_type:ty, $fragment_type:ty) => {
-        impl<'a, 'b> FindToken<LocatedSpan<$fragment_type>> for $for_type {
-            fn find_token(&self, input: LocatedSpan<$fragment_type>) -> bool {
-                self.find_token(input.fragment)
-            }
-        }
+impl<Fragment: FindToken<Token>, Token> FindToken<Token> for LocatedSpan<Fragment> {
+    fn find_token(&self, token: Token) -> bool {
+        self.fragment.find_token(token)
     }
 }
 
-impl_find_token! { char, &'a str}
-
-impl_find_token! { u8, &'a str}
-impl_find_token! { &'b u8, &'a str}
-
-impl_find_token! { u8, &'a [u8]}
-impl_find_token! { &'b u8, &'a [u8]}
-
-
 impl<'a, T> FindSubstring<&'a str> for LocatedSpan<T>
-    where T: FindSubstring<&'a str> {
-
+where
+    T: FindSubstring<&'a str>,
+{
     #[inline]
     fn find_substring(&self, substr: &'a str) -> Option<usize> {
         self.fragment.find_substring(substr)
@@ -429,8 +489,9 @@ impl<'a, T> FindSubstring<&'a str> for LocatedSpan<T>
 }
 
 impl<R: FromStr, T> ParseTo<R> for LocatedSpan<T>
-    where T: ParseTo<R> {
-
+where
+    T: ParseTo<R>,
+{
     #[inline]
     fn parse_to(&self) -> Option<R> {
         self.fragment.parse_to()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,19 +1,16 @@
 use super::LocatedSpan;
-use nom::{
-    Slice, InputIter, Compare, CompareResult,
-    FindToken, FindSubstring, ParseTo, Offset
-};
+use nom::{Compare, CompareResult, FindSubstring, FindToken, InputIter, Offset, ParseTo, Slice};
 
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
 
 #[test]
 fn it_should_call_new_for_u8_successfully() {
-    let input  = &b"foobar"[..];
+    let input = &b"foobar"[..];
     let output = BytesSpan {
-        offset : 0,
-        line  : 1,
-        fragment : input
+        offset: 0,
+        line: 1,
+        fragment: input,
     };
 
     assert_eq!(BytesSpan::new(input), output);
@@ -21,11 +18,11 @@ fn it_should_call_new_for_u8_successfully() {
 
 #[test]
 fn it_should_call_new_for_str_successfully() {
-    let input  = &"foobar"[..];
+    let input = &"foobar"[..];
     let output = StrSpan {
-        offset : 0,
-        line  : 1,
-        fragment : input
+        offset: 0,
+        line: 1,
+        fragment: input,
     };
 
     assert_eq!(StrSpan::new(input), output);
@@ -34,50 +31,69 @@ fn it_should_call_new_for_str_successfully() {
 #[test]
 fn it_should_slice_for_str() {
     let str_slice = StrSpan::new("foobar");
-    assert_eq!(str_slice.slice(1..), StrSpan {
-        offset: 1,
-        line: 1,
-        fragment: "oobar"
-    });
-    assert_eq!(str_slice.slice(1..3), StrSpan {
-        offset: 1,
-        line: 1,
-        fragment: "oo"
-    });
-    assert_eq!(str_slice.slice(..3), StrSpan {
-        offset: 0,
-        line: 1,
-        fragment: "foo"
-    });
+    assert_eq!(
+        str_slice.slice(1..),
+        StrSpan {
+            offset: 1,
+            line: 1,
+            fragment: "oobar",
+        }
+    );
+    assert_eq!(
+        str_slice.slice(1..3),
+        StrSpan {
+            offset: 1,
+            line: 1,
+            fragment: "oo",
+        }
+    );
+    assert_eq!(
+        str_slice.slice(..3),
+        StrSpan {
+            offset: 0,
+            line: 1,
+            fragment: "foo",
+        }
+    );
     assert_eq!(str_slice.slice(..), str_slice);
 }
 
 #[test]
 fn it_should_slice_for_u8() {
     let bytes_slice = BytesSpan::new(b"foobar");
-    assert_eq!(bytes_slice.slice(1..), BytesSpan {
-        offset: 1,
-        line: 1,
-        fragment: b"oobar"
-    });
-    assert_eq!(bytes_slice.slice(1..3), BytesSpan {
-        offset: 1,
-        line: 1,
-        fragment: b"oo"
-    });
-    assert_eq!(bytes_slice.slice(..3), BytesSpan {
-        offset: 0,
-        line: 1,
-        fragment: b"foo"
-    });
+    assert_eq!(
+        bytes_slice.slice(1..),
+        BytesSpan {
+            offset: 1,
+            line: 1,
+            fragment: b"oobar",
+        }
+    );
+    assert_eq!(
+        bytes_slice.slice(1..3),
+        BytesSpan {
+            offset: 1,
+            line: 1,
+            fragment: b"oo",
+        }
+    );
+    assert_eq!(
+        bytes_slice.slice(..3),
+        BytesSpan {
+            offset: 0,
+            line: 1,
+            fragment: b"foo",
+        }
+    );
     assert_eq!(bytes_slice.slice(..), bytes_slice);
 }
 
 #[test]
 fn it_should_calculate_columns() {
-    let input = StrSpan::new("foo
-        bar");
-
+    let input = StrSpan::new(
+        "foo
+        bar",
+    );
 
     let bar_idx = input.find_substring("bar").unwrap();
     assert_eq!(input.slice(bar_idx..).get_column(), 9);
@@ -86,7 +102,7 @@ fn it_should_calculate_columns() {
 #[test]
 fn it_should_calculate_columns_accurately_with_non_ascii_chars() {
     let s = StrSpan::new("メカジキ");
-    assert_eq!(s.slice(6..).get_column_utf8(), Ok(3));
+    assert_eq!(s.slice(6..).get_utf8_column(), 3);
 }
 
 #[test]
@@ -95,7 +111,7 @@ fn it_should_panic_when_getting_column_if_offset_is_too_big() {
     let s = StrSpan {
         offset: usize::max_value(),
         fragment: "",
-        line: 1
+        line: 1,
     };
     s.get_column();
 }
@@ -103,11 +119,14 @@ fn it_should_panic_when_getting_column_if_offset_is_too_big() {
 #[test]
 fn it_should_iterate_indices() {
     let str_slice = StrSpan::new("foobar");
-    assert_eq!(str_slice.iter_indices().collect::<Vec<(usize, char)>>(), vec![
-        (0, 'f'), (1, 'o'), (2, 'o'),
-        (3, 'b'), (4, 'a'), (5, 'r')
-    ]);
-    assert_eq!(StrSpan::new("").iter_indices().collect::<Vec<(usize, char)>>(),
+    assert_eq!(
+        str_slice.iter_indices().collect::<Vec<(usize, char)>>(),
+        vec![(0, 'f'), (1, 'o'), (2, 'o'), (3, 'b'), (4, 'a'), (5, 'r')]
+    );
+    assert_eq!(
+        StrSpan::new("")
+            .iter_indices()
+            .collect::<Vec<(usize, char)>>(),
         vec![]
     );
 }
@@ -115,10 +134,12 @@ fn it_should_iterate_indices() {
 #[test]
 fn it_should_iterate_elements() {
     let str_slice = StrSpan::new("foobar");
-    assert_eq!(str_slice.iter_elements().collect::<Vec<char>>(), vec![
-        'f', 'o', 'o', 'b', 'a', 'r'
-    ]);
-    assert_eq!(StrSpan::new("").iter_elements().collect::<Vec<char>>(),
+    assert_eq!(
+        str_slice.iter_elements().collect::<Vec<char>>(),
+        vec!['f', 'o', 'o', 'b', 'a', 'r']
+    );
+    assert_eq!(
+        StrSpan::new("").iter_elements().collect::<Vec<char>>(),
         vec![]
     );
 }
@@ -135,9 +156,14 @@ fn it_should_compare_elements() {
     assert_eq!(StrSpan::new("foobar").compare("foo"), CompareResult::Ok);
     assert_eq!(StrSpan::new("foobar").compare("bar"), CompareResult::Error);
     assert_eq!(StrSpan::new("foobar").compare("foobar"), CompareResult::Ok);
-    assert_eq!(StrSpan::new("foobar").compare_no_case("fooBar"), CompareResult::Ok);
-    assert_eq!(StrSpan::new("foobar").compare("foobarbaz"),
-       CompareResult::Incomplete);
+    assert_eq!(
+        StrSpan::new("foobar").compare_no_case("fooBar"),
+        CompareResult::Ok
+    );
+    assert_eq!(
+        StrSpan::new("foobar").compare("foobarbaz"),
+        CompareResult::Incomplete
+    );
 
     // FIXME: WTF! The line below doesn't compile unless we stop comparing
     // LocatedSpan<&[u8]> with &str
@@ -147,18 +173,19 @@ fn it_should_compare_elements() {
 }
 
 #[test]
+#[allow(unused_parens)]
 fn it_should_find_token() {
-    assert!('a'.find_token(StrSpan::new("foobar")));
-    assert!(b'a'.find_token(StrSpan::new("foobar")));
-    assert!(&(b'a').find_token(StrSpan::new("foobar")));
-    assert!(!'c'.find_token(StrSpan::new("foobar")));
-    assert!(!b'c'.find_token(StrSpan::new("foobar")));
-    assert!(!(&b'c').find_token(StrSpan::new("foobar")));
+    assert!(StrSpan::new("foobar").find_token('a'));
+    assert!(StrSpan::new("foobar").find_token(b'a'));
+    assert!(StrSpan::new("foobar").find_token(&(b'a')));
+    assert!(!StrSpan::new("foobar").find_token('c'));
+    assert!(!StrSpan::new("foobar").find_token(b'c'));
+    assert!(!StrSpan::new("foobar").find_token((&b'c')));
 
-    assert!(b'a'.find_token(BytesSpan::new(b"foobar")));
-    assert!(&(b'a').find_token(BytesSpan::new(b"foobar")));
-    assert!(!b'c'.find_token(BytesSpan::new(b"foobar")));
-    assert!(!(&b'c').find_token(BytesSpan::new(b"foobar")));
+    assert!(BytesSpan::new(b"foobar").find_token(b'a'));
+    assert!(BytesSpan::new(b"foobar").find_token(&(b'a')));
+    assert!(!BytesSpan::new(b"foobar").find_token(b'c'));
+    assert!(!BytesSpan::new(b"foobar").find_token((&b'c')));
 }
 
 #[test]
@@ -171,22 +198,27 @@ fn it_should_find_substring() {
 
 #[test]
 fn it_should_parse_to_string() {
-    assert_eq!(StrSpan::new("foobar").parse_to(), Some("foobar".to_string()));
-    assert_eq!(BytesSpan::new(b"foobar").parse_to(), Some("foobar".to_string()));
+    assert_eq!(
+        StrSpan::new("foobar").parse_to(),
+        Some("foobar".to_string())
+    );
+    assert_eq!(
+        BytesSpan::new(b"foobar").parse_to(),
+        Some("foobar".to_string())
+    );
 }
-
 
 // https://github.com/Geal/nom/blob/eee82832fafdfdd0505546d224caa466f7d39a15/src/util.rs#L710-L720
 #[test]
 fn it_should_calculate_offset_for_u8() {
-  let s = b"abcd123";
-  let a = &s[..];
-  let b = &a[2..];
-  let c = &a[..4];
-  let d = &a[3..5];
-  assert_eq!(a.offset(b), 2);
-  assert_eq!(a.offset(c), 0);
-  assert_eq!(a.offset(d), 3);
+    let s = b"abcd123";
+    let a = &s[..];
+    let b = &a[2..];
+    let c = &a[..4];
+    let d = &a[3..5];
+    assert_eq!(a.offset(b), 2);
+    assert_eq!(a.offset(c), 0);
+    assert_eq!(a.offset(d), 3);
 }
 
 // https://github.com/Geal/nom/blob/eee82832fafdfdd0505546d224caa466f7d39a15/src/util.rs#L722-L732

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,10 +6,11 @@ use std::ops::{Range, RangeFull};
 use std::fmt::Debug;
 use nom_locate::LocatedSpan;
 use std::cmp;
-use nom::{IResult, ErrorKind, FindSubstring, InputLength, Slice, AsBytes};
+use nom::{AsBytes, ErrorKind, FindSubstring, IResult, InputLength, Slice};
+use nom::types::{CompleteByteSlice, CompleteStr};
 
-type StrSpan<'a> = LocatedSpan<&'a str>;
-type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
+type StrSpan<'a> = LocatedSpan<CompleteStr<'a>>;
+type BytesSpan<'a> = LocatedSpan<CompleteByteSlice<'a>>;
 
 named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
@@ -41,15 +42,16 @@ struct Position {
     line: u32,
     column: usize,
     offset: usize,
-    fragment_len: usize
+    fragment_len: usize,
 }
 
 fn test_str_fragments<'a, F, T>(parser: F, input: T, positions: Vec<Position>)
-    where F: Fn(LocatedSpan<T>) -> IResult<LocatedSpan<T>, Vec<LocatedSpan<T>>>,
-          T: InputLength + Slice<Range<usize>> + Slice<RangeFull> + Debug + PartialEq + AsBytes {
-
+where
+    F: Fn(LocatedSpan<T>) -> IResult<LocatedSpan<T>, Vec<LocatedSpan<T>>>,
+    T: InputLength + Slice<Range<usize>> + Slice<RangeFull> + Debug + PartialEq + AsBytes,
+{
     let res = parser(LocatedSpan::new(input.slice(..)));
-    assert!(res.is_done(), "the parser should run successfully");
+    assert!(res.is_ok(), "the parser should run successfully");
     let (remaining, output) = res.unwrap();
     assert!(remaining.fragment.input_len() == 0, "no input should remain");
     assert_eq!(output.len(), positions.len());
@@ -60,21 +62,21 @@ fn test_str_fragments<'a, F, T>(parser: F, input: T, positions: Vec<Position>)
             fragment: input.slice(pos.offset..cmp::min(pos.offset + pos.fragment_len, input.input_len()))
         };
         assert_eq!(output_item, &expected_item);
-        assert_eq!(output_item.get_column_utf8(), Ok(pos.column), "columns should be equal");
+        assert_eq!(output_item.get_utf8_column(), pos.column, "columns should be equal");
     }
 }
 
 #[test]
 fn it_locates_str_fragments() {
-    test_str_fragments(simple_parser_str, "foobarbaz", vec![
+    test_str_fragments(simple_parser_str, CompleteStr("foobarbaz"), vec![
         Position { line: 1, column: 1, offset: 0, fragment_len: 3 },
         Position { line: 1, column: 4, offset: 3, fragment_len: 3 },
         Position { line: 1, column: 7, offset: 6, fragment_len: 3 },
         Position { line: 1, column: 10, offset: 9, fragment_len: 3 }
     ]);
-    test_str_fragments(simple_parser_str, " foo
+    test_str_fragments(simple_parser_str, CompleteStr(" foo
         bar
-            baz", vec![
+            baz"), vec![
         Position { line: 1, column: 2,  offset: 1,  fragment_len: 3 },
         Position { line: 2, column: 9,  offset: 13, fragment_len: 3 },
         Position { line: 3, column: 13, offset: 29, fragment_len: 3 },
@@ -84,15 +86,15 @@ fn it_locates_str_fragments() {
 
 #[test]
 fn it_locates_u8_fragments() {
-    test_str_fragments(simple_parser_u8, &b"foobarbaz"[..], vec![
+    test_str_fragments(simple_parser_u8, CompleteByteSlice(b"foobarbaz"), vec![
         Position { line: 1, column: 1, offset: 0, fragment_len: 3 },
         Position { line: 1, column: 4, offset: 3, fragment_len: 3 },
         Position { line: 1, column: 7, offset: 6, fragment_len: 3 },
         Position { line: 1, column: 10, offset: 9, fragment_len: 3 }
     ]);
-    test_str_fragments(simple_parser_u8, &b" foo
+    test_str_fragments(simple_parser_u8, CompleteByteSlice(b" foo
         bar
-            baz"[..], vec![
+            baz"), vec![
         Position { line: 1, column: 2,  offset: 1,  fragment_len: 3 },
         Position { line: 2, column: 9,  offset: 13, fragment_len: 3 },
         Position { line: 3, column: 13, offset: 29, fragment_len: 3 },
@@ -100,11 +102,11 @@ fn it_locates_u8_fragments() {
     ]);
 }
 
-fn find_substring<'a>(input: StrSpan<'a>, substr: &str) -> IResult< StrSpan<'a>, StrSpan<'a> > {
+fn find_substring<'a>(input: StrSpan<'a>, substr: &str) -> IResult<StrSpan<'a>, StrSpan<'a>> {
     let substr_len = substr.len();
     match input.find_substring(substr) {
-        None => IResult::Error(error_position!(ErrorKind::Custom(1), input)),
-        Some(pos) => IResult::Done(input.slice(pos+substr_len..), input.slice(pos..pos+substr_len))
+        None => Err(nom::Err::Error(error_position!(input, ErrorKind::Custom(1)))),
+        Some(pos) => Ok((input.slice(pos+substr_len..), input.slice(pos..pos+substr_len)))
     }
 }
 
@@ -121,11 +123,10 @@ named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
-
 #[test]
 fn it_locates_complex_fragments() {
     // Lorem ipsum is boring. Let's quote Camus' Plague.
-    let input = "Écoutant, en effet, les cris d’allégresse qui montaient de la ville,
+    let input = CompleteStr("Écoutant, en effet, les cris d’allégresse qui montaient de la ville,
 Rieux se souvenait que cette allégresse était toujours menacée.
 Car il savait ce que cette foule en joie ignorait,
 et qu’on peut lire dans les livres,
@@ -135,7 +136,7 @@ les meubles et le linge, qu’il attend patiemment dans les chambres, les caves,
 les malles, les mouchoirs et les paperasses,
 et que, peut-être, le jour viendrait où,
 pour le malheur et l’enseignement des hommes,
-la peste réveillerait ses rats et les enverrait mourir dans une cité heureuse.";
+la peste réveillerait ses rats et les enverrait mourir dans une cité heureuse.");
 
     let expected = vec![
         Position { line: 5,  column: 5,  offset: 233, fragment_len: 10 },


### PR DESCRIPTION
Compiles against [Geal/nom#a53febdfdf99d16c0177f5c605bd98481a4ec50f](https://github.com/Geal/nom/tree/a53febdfdf99d16c0177f5c605bd98481a4ec50f)

I was playing around with a small parser and tried out the latest changes with upstream nom. These are the changes that I had to patch into this library to get it compiling.

Very, very minimally tested (as in, it compiles and I have a micro-sized nom parser using it), and nom might change again before the proper 4.0 release, but I thought I'd share the work I did to get this to compile today.