### PR TITLE
Bump memchr version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ version = "0.1.1"
 repository = "fflorent/nom_locate"
 
 [dependencies]
-memchr = "1.0.1"
+memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
 nom = "^3.2"


### PR DESCRIPTION
Major version bump because of BurntSushi/rust-memchr#18

memchr::memchr's interface did not change,
so allow using either version for better unification chances