### PR TITLE
Remove alloc feature gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,14 @@ matrix:
     - rust: stable
       env: FEATURES='default'
     - rust: stable
+      env: FEATURES='alloc'
+    - rust: stable
       env: FEATURES=''
 
     - rust: beta
       env: FEATURES='default'
+    - rust: beta
+      env: FEATURES='alloc'
     - rust: beta
       env: FEATURES=''
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@
 
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(not(feature = "std"), feature = "alloc"), feature(alloc))]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 #[cfg_attr(test, macro_use)]


### PR DESCRIPTION
Now `alloc` is stabilized. So the feature gate can be removed.
I added CI tests for stable/beta with `alloc`.
