### PR TITLE
Impl AsBytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,12 @@ impl<T: AsBytes, X> LocatedSpanEx<T, X> {
     }
 }
 
+impl<T: AsBytes, X> AsBytes for LocatedSpanEx<T, X> {
+    fn as_bytes(&self) -> &[u8] {
+        self.fragment.as_bytes()
+    }
+}
+
 impl<T: InputLength, X> InputLength for LocatedSpanEx<T, X> {
     fn input_len(&self) -> usize {
         self.fragment.input_len()


### PR DESCRIPTION
I added `AsBytes` for `LocatedSpanEx`.
In [this document](https://github.com/Geal/nom/blob/master/doc/custom_input_types.md), `AsBytes` must be implemented for custom input type.