### PR TITLE
Skip extra property when comparing LocatedSpanEx

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,8 @@ impl<T: AsBytes + PartialEq, X> PartialEq for LocatedSpanEx<T, X> {
     }
 }
 
+impl<T: AsBytes + Eq, X> Eq for LocatedSpanEx<T, X> {}
+
 impl<T: AsBytes, X> AsBytes for LocatedSpanEx<T, X> {
     fn as_bytes(&self) -> &[u8] {
         self.fragment.as_bytes()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@
 //! ```
 //!
 //! ## Extra information
-//! You can add arbitrary extra information using `LocatedSpanEx`. This extra property is not used when comparing two `LocatedSpanEx`s.
+//! You can add arbitrary extra information using `LocatedSpanEx`.
+//! This extra property is not used when comparing two `LocatedSpanEx`s.
 //!
 //! ``̀`
 //! use nom_locate::LocatedSpanEx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub struct LocatedSpanEx<T, X> {
     /// The fragment represents a part of the input of the parser.
     pub fragment: T,
 
-    /// Extra information that can be embededd by the user.
+    /// Extra information that can be embedded by the user.
     /// Example: the parsed file name
     pub extra: X,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! ```
 //!
 //! ## Extra information
-//! You can add arbitrary extra information using LocatedSpanEx.
+//! You can add arbitrary extra information using `LocatedSpanEx`. This extra property is not used when comparing two `LocatedSpanEx`s.
 //!
 //! ``̀`
 //! use nom_locate::LocatedSpanEx;
@@ -126,7 +126,7 @@ pub type LocatedSpan<T> = LocatedSpanEx<T, ()>;
 ///
 /// The `LocatedSpanEx` structure can be used as an input of the nom parsers.
 /// It implements all the necessary traits for `LocatedSpanEx<&str,X>` and `LocatedSpanEx<&[u8],X>`
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct LocatedSpanEx<T, X> {
     /// The offset represents the position of the fragment relatively to
     /// the input of the parser. It starts at offset 0.
@@ -306,6 +306,12 @@ impl<T: AsBytes, X> LocatedSpanEx<T, X> {
     pub fn naive_get_utf8_column(&self) -> usize {
         let before_self = self.get_columns_and_bytes_before().1;
         naive_num_chars(before_self) + 1
+    }
+}
+
+impl<T: AsBytes + PartialEq, X> PartialEq for LocatedSpanEx<T, X> {
+    fn eq(&self, other: &Self) -> bool {
+        self.line == other.line && self.offset == other.offset && self.fragment == other.fragment
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -68,6 +68,16 @@ fn it_should_call_new_for_str_successfully() {
 }
 
 #[test]
+fn it_should_ignore_extra_for_equality() {
+    let input = &"foobar"[..];
+
+    assert_eq!(
+        StrSpanEx::new_extra(input, "foo"),
+        StrSpanEx::new_extra(input, "bar")
+    );
+}
+
+#[test]
 fn it_should_slice_for_str() {
     let str_slice = StrSpanEx::new_extra("foobar", "extra");
     assert_eq!(


### PR DESCRIPTION
`LocatedSpanEx` includes an `extra` property that is designed for "extra information that can be embedded by the user".

Since `PartialEq` is derived on `LocatedSpanEx`, checking equality on two spans involves checking equality on the `extra` property. This is undesirable as, by definition, the extra information is separate from the input so should not be compared when determining if two input spans are the same.

I have come across this issue as there are several nom combinators which require comparing two inputs, for instance `many1`. Currently, the only workaround is wrapping the extra information in a trivial `struct` which always returns `true` when compared.

I resolve this by instead providing a custom `PartialEq` implementation for `LocatedSpanEx`. Whilst doing this, I also fixed a typo within the docs for the `extra` property and implemented `Eq` (equivalence relation) on `LocatedSpanEx` where the generic `T` allows for this. 😄

I hope this helps, let me know if there are any questions or suggestions! 