### PR TITLE
Update nom dependency in Cargo.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,14 @@ matrix:
     - rust: stable
       env: FEATURES='default'
     - rust: stable
+      env: FEATURES='alloc'
+    - rust: stable
       env: FEATURES=''
 
     - rust: beta
       env: FEATURES='default'
+    - rust: beta
+      env: FEATURES='alloc
     - rust: beta
       env: FEATURES=''
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     - rust: beta
       env: FEATURES='default'
     - rust: beta
-      env: FEATURES='alloc
+      env: FEATURES='alloc'
     - rust: beta
       env: FEATURES=''
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,20 +44,23 @@ matrix:
     - rust: stable
       env: FEATURES='default'
     - rust: stable
+      env: FEATURES=''
+
+    - rust: beta
+      env: FEATURES='default'
+    - rust: beta
+      env: FEATURES=''
+
+    - rust: nightly
+      env: FEATURES='default'
+    - rust: nightly
       env: FEATURES='alloc'
+    - rust: nightly
+      env: FEATURES=''
+
+  allow_failures:
     - rust: stable
-      env: FEATURES=''
+      env: FEATURES='alloc'
 
     - rust: beta
-      env: FEATURES='default'
-    - rust: beta
       env: FEATURES='alloc'
-    - rust: beta
-      env: FEATURES=''
-
-    - rust: nightly
-      env: FEATURES='default'
-    - rust: nightly
-      env: FEATURES='alloc'
-    - rust: nightly
-      env: FEATURES=''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
 [dependencies]
 bytecount = "^0.6"
 memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
-nom = { version = "5.0.0", default-features = false }
+nom = { version = "5.0.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
 [dependencies]
 bytecount = "^0.6"
 memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
-nom = { version = "5.0.0", default-features = false, features = ["std"] }
+nom = { version = "5.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
 [dependencies]
 bytecount = "^0.6"
 memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
-nom = "5.0.0"
-
+nom = { version = "5.0.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,6 +720,7 @@ impl_extend_into!(&'a str, char, String);
 #[cfg(feature = "alloc")]
 impl_extend_into!(&'a [u8], u8, Vec<u8>);
 
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! impl_hex_display {
     ($fragment_type:ty) => {
@@ -736,7 +737,9 @@ macro_rules! impl_hex_display {
     };
 }
 
+#[cfg(feature = "std")]
 impl_hex_display!(&'a str);
+#[cfg(feature = "std")]
 impl_hex_display!(&'a [u8]);
 
 /// Capture the position of the current fragment

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,6 @@ use std::ops::{Range, RangeFull};
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
 
-#[cfg(feature = "alloc")]
 named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -24,7 +23,6 @@ named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
-#[cfg(feature = "alloc")]
 named!(simple_parser_u8< BytesSpan, Vec<BytesSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -84,7 +82,6 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_str_fragments() {
     test_str_fragments(
@@ -151,7 +148,6 @@ fn it_locates_str_fragments() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_u8_fragments() {
     test_str_fragments(
@@ -257,7 +253,6 @@ fn test_escaped_string() {
     );
 }
 
-#[cfg(feature = "alloc")]
 named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     bacille: call!(find_substring, "le bacille") >>
     bacille_pronouns: many0!(call!(find_substring, "il ")) >>
@@ -271,7 +266,6 @@ named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
-#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_complex_fragments() {
     // Lorem ipsum is boring. Let's quote Camus' Plague.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,6 +10,7 @@ use std::ops::{Range, RangeFull};
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
 
+#[cfg(feature = "alloc")]
 named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -23,6 +24,7 @@ named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
+#[cfg(feature = "alloc")]
 named!(simple_parser_u8< BytesSpan, Vec<BytesSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -82,6 +84,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_str_fragments() {
     test_str_fragments(
@@ -148,6 +151,7 @@ fn it_locates_str_fragments() {
     );
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_u8_fragments() {
     test_str_fragments(
@@ -253,6 +257,7 @@ fn test_escaped_string() {
     );
 }
 
+#[cfg(feature = "alloc")]
 named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     bacille: call!(find_substring, "le bacille") >>
     bacille_pronouns: many0!(call!(find_substring, "il ")) >>
@@ -266,6 +271,7 @@ named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
+#[cfg(feature = "alloc")]
 #[test]
 fn it_locates_complex_fragments() {
     // Lorem ipsum is boring. Let's quote Camus' Plague.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use std::ops::{Range, RangeFull};
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -24,7 +24,7 @@ named!(simple_parser_str< StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 named!(simple_parser_u8< BytesSpan, Vec<BytesSpan> >, do_parse!(
     foo: ws!(tag!("foo")) >>
     bar: ws!(tag!("bar")) >>
@@ -84,7 +84,7 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[test]
 fn it_locates_str_fragments() {
     test_str_fragments(
@@ -151,7 +151,7 @@ fn it_locates_str_fragments() {
     );
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[test]
 fn it_locates_u8_fragments() {
     test_str_fragments(
@@ -257,7 +257,7 @@ fn test_escaped_string() {
     );
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     bacille: call!(find_substring, "le bacille") >>
     bacille_pronouns: many0!(call!(find_substring, "il ")) >>
@@ -271,7 +271,7 @@ named!(plague<StrSpan, Vec<StrSpan> >, do_parse!(
     })
 ));
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[test]
 fn it_locates_complex_fragments() {
     // Lorem ipsum is boring. Let's quote Camus' Plague.


### PR DESCRIPTION
This change gives users the option of using nom_locate without needing to use the default features of nom, e.g. "lexical".