### PR TITLE
Make offset/line/fragment private attributes.

### DIFF
--- a/examples/position.rs
+++ b/examples/position.rs
@@ -23,8 +23,8 @@ fn parse_foobar(s: Span) -> IResult<Span, Token> {
         s,
         Token {
             position: pos,
-            foo: foo.fragment,
-            bar: bar.fragment,
+            foo: foo.fragment(),
+            bar: bar.fragment(),
         },
     ))
 }
@@ -35,11 +35,13 @@ fn main() {
     let position = output.unwrap().1.position;
     assert_eq!(
         position,
-        Span {
-            offset: 14,
-            line: 2,
-            fragment: "",
-            extra: (),
+        unsafe {
+            Span::new_from_raw_offset(
+                14, // offset
+                2, // line
+                "", // fragment
+                (), // extra
+            )
         }
     );
     assert_eq!(position.get_column(), 2);


### PR DESCRIPTION
Mutating `offset` and `fragment` (or building a LocatedSpan from scratch) may result
in undefined behavior if the offset is invalid.
`line` doesn't need to be private, but I'm making it anyway, just in case we ever need it.

Fixes #45 

@0xd34d10cc How does that look?