### PR TITLE
Use default type parameter for LocatedSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This release brings several breaking changes:
 * [Dependency on nom now uses with `default-features = false`](https://github.com/fflorent/nom_locate/pull/47)
 * [`offset`/`line`/`fragment` are now private attributes of the `LocatedSpan` structure](https://github.com/fflorent/nom_locate/pull/50),
   to fix an undefined behavior is they are modified. You now have to use the `location_offset()`, `location_line()`, and `fragment()` getters instead.
+* [`LocatedSpanEx` is removed in favour of adding a generic type parameter to `LocatedSpan` which defaults to to `()`](https://github.com/fflorent/nom_locate/pull/51)
 
 
 Additionally, there are a few documentation improvements:

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ mod lib {
 #[cfg(feature = "alloc")]
 use lib::std::*;
 
-use super::{LocatedSpan, LocatedSpanEx};
+use super::LocatedSpan;
 #[cfg(feature = "alloc")]
 use nom::ParseTo;
 use nom::{
@@ -24,21 +24,18 @@ use nom::{
 
 type StrSpan<'a> = LocatedSpan<&'a str>;
 type BytesSpan<'a> = LocatedSpan<&'a [u8]>;
-type StrSpanEx<'a, 'b> = LocatedSpanEx<&'a str, &'b str>;
-type BytesSpanEx<'a, 'b> = LocatedSpanEx<&'a [u8], &'b str>;
+type StrSpanEx<'a, 'b> = LocatedSpan<&'a str, &'b str>;
+type BytesSpanEx<'a, 'b> = LocatedSpan<&'a [u8], &'b str>;
 
 #[test]
 fn new_sould_be_the_same_as_new_extra() {
     let byteinput = &b"foobar"[..];
     assert_eq!(
         BytesSpan::new(byteinput),
-        LocatedSpanEx::new_extra(byteinput, ())
+        LocatedSpan::new_extra(byteinput, ())
     );
     let strinput = "foobar";
-    assert_eq!(
-        StrSpan::new(strinput),
-        LocatedSpanEx::new_extra(strinput, ())
-    );
+    assert_eq!(StrSpan::new(strinput), LocatedSpan::new_extra(strinput, ()));
 }
 
 #[test]
@@ -327,7 +324,7 @@ fn it_should_take_split_chars() {
     );
 }
 
-type TestError<'a, 'b> = (LocatedSpanEx<&'a str, &'b str>, nom::error::ErrorKind);
+type TestError<'a, 'b> = (LocatedSpan<&'a str, &'b str>, nom::error::ErrorKind);
 
 #[test]
 fn it_should_split_at_position() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -222,12 +222,10 @@ fn it_should_compare_elements() {
         StrSpan::new("foobar").compare("foobarbaz"),
         CompareResult::Incomplete
     );
-
-    // FIXME: WTF! The line below doesn't compile unless we stop comparing
-    // LocatedSpan<&[u8]> with &str
-    //
-    // assert_eq!(BytesSpan::new(b"foobar").compare(b"foo"), CompareResult::Ok);
-    assert_eq!(BytesSpan::new(b"foobar").compare("foo"), CompareResult::Ok);
+    assert_eq!(
+        BytesSpan::new(b"foobar").compare(b"foo" as &[u8]),
+        CompareResult::Ok
+    );
 }
 
 #[test]


### PR DESCRIPTION
Thanks for the help with my previous pull request! I have decided to create another one for something small that has been bugging me for a bit...

When [the addition of extra information to `LocatedSpan`](https://github.com/fflorent/nom_locate/pull/28) was implemented, a new `LocatedSpanEx` struct was added which includes an `extra` property with generic parameter `X`. Consequently, the original `LocatedSpan` has become a type alias where `X` is set to the empty type `()`.

```rust
pub type LocatedSpan<T> = LocatedSpanEx<T, ()>;
```

However, this is unnecessary as for some time [default type parameters have been allowed](https://github.com/rust-lang/rfcs/blob/master/text/0213-defaulted-type-params.md) — see [the relevant page in the Rust book](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#default-generic-type-parameters-and-operator-overloading) for more information on how these can be used. I have simplified the types by renaming `LocatedSpanEx` back to `LocatedSpan` and adding a default type of `()` for the generic `X` parameter.

```rust
pub struct LocatedSpan<T, X = ()> { ... }
```

It may be important to allow for backwards compatibility so I have recreated `LocatedSpanEx` as a type alias of `LocatedSpan` (which can be removed in a future release). I have marked it with a deprecation warning since all uses can now be replaced with `LocatedSpan`. The remainder of the codebase, including documentation and testcases, has also been updated to simply use `LocatedSpan`.

```rust
#[deprecated(note = "Use LocatedSpan instead which is exactly the same")]
pub type LocatedSpanEx<T, X> = LocatedSpan<T, X>;
```

Additionally, on an unrelated note, I have fixed a `FIXME` issue in the testcases whereby the following line was not working.

```rust
assert_eq!(BytesSpan::new(b"foobar").compare(b"foo"), CompareResult::Ok);
```

The issue is that `b"foo"` has type `&[u8; 3]` whereas `b"foobar"` has type `&[u8]` as it is implicitly casted due to the type signature of `ByteSpan::new`. The solution is to perform the same treatment to `b"foo"`, which must be done with an explicit cast.

```rust
assert_eq!(BytesSpan::new(b"foobar").compare(b"foo" as &[u8]), CompareResult::Ok);
```

Please let me know if I can clarify anything or if there are any questions or issues with this 😄 