### PR TITLE
Implement From<T> for LocatedSpan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,12 @@ impl<T: AsBytes, X> LocatedSpan<T, X> {
     }
 }
 
+impl<T: AsBytes, X: Default> From<T> for LocatedSpan<T, X> {
+    fn from(i: T) -> Self {
+        Self::new_extra(i, X::default())
+    }
+}
+
 impl<T: AsBytes + PartialEq, X> PartialEq for LocatedSpan<T, X> {
     fn eq(&self, other: &Self) -> bool {
         self.line == other.line && self.offset == other.offset && self.fragment == other.fragment

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,6 +52,13 @@ fn it_should_call_new_for_u8_successfully() {
 }
 
 #[test]
+fn it_should_convert_from_u8_successfully() {
+    let input = &b"foobar"[..];
+    assert_eq!(BytesSpan::new(input), input.into());
+    assert_eq!(BytesSpanEx::new_extra(input, "extra"), input.into());
+}
+
+#[test]
 fn it_should_call_new_for_str_successfully() {
     let input = &"foobar"[..];
     let output = StrSpan {
@@ -62,6 +69,13 @@ fn it_should_call_new_for_str_successfully() {
     };
 
     assert_eq!(StrSpan::new(input), output);
+}
+
+#[test]
+fn it_should_convert_from_str_successfully() {
+    let input = &"foobar"[..];
+    assert_eq!(StrSpan::new(input), input.into());
+    assert_eq!(StrSpanEx::new_extra(input, "extra"), input.into());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #54 by providing `impl<T: AsBytes, X: Default> From<T> for LocatedSpan<T, X>`