### PR TITLE
Improve generalization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub struct LocatedSpan<T, X = ()> {
     pub extra: X,
 }
 
-impl<T, X> std::ops::Deref for LocatedSpan<T, X> {
+impl<T, X> core::ops::Deref for LocatedSpan<T, X> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.fragment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,10 @@ impl<A: Compare<B>, B: Into<LocatedSpan<B>>, X> Compare<B> for LocatedSpan<A, X>
 }
 
 #[macro_export]
-#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer requires a macro")]
+#[deprecated(
+    since = "2.1.0",
+    note = "this implementation has been generalized and no longer requires a macro"
+)]
 macro_rules! impl_compare {
     ( $fragment_type:ty, $compare_to_type:ty ) => {};
 }
@@ -729,7 +732,10 @@ impl_extend_into!(&'a [u8], u8, Vec<u8>);
 
 #[cfg(feature = "std")]
 #[macro_export]
-#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer requires a macro")]
+#[deprecated(
+    since = "2.1.0",
+    note = "this implementation has been generalized and no longer requires a macro"
+)]
 macro_rules! impl_hex_display {
     ($fragment_type:ty) => {};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ impl_input_iter!(
     Map<Iter<'a, Self::Item>, fn(&u8) -> u8>
 );
 
-impl<A: Compare<B>, B: Into<LocatedSpan<B>>, Y> Compare<B> for LocatedSpan<A, Y> {
+impl<A: Compare<B>, B: Into<LocatedSpan<B>>, X> Compare<B> for LocatedSpan<A, X> {
     #[inline(always)]
     fn compare(&self, t: B) -> CompareResult {
         self.fragment.compare(t.into().fragment)
@@ -527,19 +527,6 @@ impl<A: Compare<B>, B: Into<LocatedSpan<B>>, Y> Compare<B> for LocatedSpan<A, Y>
         self.fragment.compare_no_case(t.into().fragment)
     }
 }
-
-// TODO(future): replace impl_compare! with below default specialization?
-// default impl<A: Compare<B>, B, X> Compare<B> for LocatedSpan<A, X> {
-//     #[inline(always)]
-//     fn compare(&self, t: B) -> CompareResult {
-//         self.fragment.compare(t)
-//     }
-//
-//     #[inline(always)]
-//     fn compare_no_case(&self, t: B) -> CompareResult {
-//         self.fragment.compare_no_case(t)
-//     }
-// }
 
 /// Implement nom::Slice for a specific fragment type and range type.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,10 @@ use lib::std::*;
 use bytecount::{naive_num_chars, num_chars};
 use memchr::Memchr;
 #[cfg(feature = "alloc")]
+use nom::ExtendInto;
 use nom::{
     error::{ErrorKind, ParseError},
-    AsBytes, Compare, CompareResult, Err, ExtendInto, FindSubstring, FindToken, IResult, InputIter,
+    AsBytes, Compare, CompareResult, Err, FindSubstring, FindToken, IResult, InputIter,
     InputLength, InputTake, InputTakeAtPosition, Offset, ParseTo, Slice,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,6 +535,12 @@ impl<A: Compare<B>, B: Into<LocatedSpan<B>>, X> Compare<B> for LocatedSpan<A, X>
     }
 }
 
+#[macro_export]
+#[deprecated]
+macro_rules! impl_compare {
+    ( $fragment_type:ty, $compare_to_type:ty ) => {};
+}
+
 /// Implement nom::Slice for a specific fragment type and range type.
 ///
 /// **You'd probably better use impl_`slice_ranges`**,
@@ -714,6 +720,13 @@ macro_rules! impl_extend_into {
             }
         }
     };
+}
+
+#[cfg(feature = "std")]
+#[macro_export]
+#[deprecated]
+macro_rules! impl_hex_display {
+    ($fragment_type:ty) => {};
 }
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,13 @@ pub struct LocatedSpan<T, X = ()> {
     pub extra: X,
 }
 
+impl<T, X> std::ops::Deref for LocatedSpan<T, X> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.fragment
+    }
+}
+
 impl<T: AsBytes> LocatedSpan<T, ()> {
     /// Create a span for a particular input with default `offset` and
     /// `line` values and empty extra data.
@@ -714,30 +721,7 @@ impl_extend_into!(&'a str, char, String);
 #[cfg(feature = "alloc")]
 impl_extend_into!(&'a [u8], u8, Vec<u8>);
 
-#[cfg(feature = "std")]
-#[macro_export]
-macro_rules! impl_hex_display {
-    ($fragment_type:ty) => {
-        #[cfg(feature = "alloc")]
-        impl<'a, X> nom::HexDisplay for LocatedSpan<$fragment_type, X> {
-            fn to_hex(&self, chunk_size: usize) -> String {
-                self.fragment.to_hex(chunk_size)
-            }
-
-            fn to_hex_from(&self, chunk_size: usize, from: usize) -> String {
-                self.fragment.to_hex_from(chunk_size, from)
-            }
-        }
-    };
-}
-
-#[cfg(feature = "std")]
-impl_hex_display!(&'a str);
-#[cfg(feature = "std")]
-impl_hex_display!(&'a [u8]);
-
 /// Capture the position of the current fragment
-
 #[macro_export]
 macro_rules! position {
     ($input:expr,) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ impl<A: Compare<B>, B: Into<LocatedSpan<B>>, X> Compare<B> for LocatedSpan<A, X>
 }
 
 #[macro_export]
-#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer needs a macro")]
+#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer requires a macro")]
 macro_rules! impl_compare {
     ( $fragment_type:ty, $compare_to_type:ty ) => {};
 }
@@ -723,7 +723,7 @@ macro_rules! impl_extend_into {
 
 #[cfg(feature = "std")]
 #[macro_export]
-#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer needs a macro")]
+#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer requires a macro")]
 macro_rules! impl_hex_display {
     ($fragment_type:ty) => {};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,9 @@ use lib::std::*;
 use bytecount::{naive_num_chars, num_chars};
 use memchr::Memchr;
 #[cfg(feature = "alloc")]
-use nom::ExtendInto;
 use nom::{
     error::{ErrorKind, ParseError},
-    AsBytes, Compare, CompareResult, Err, FindSubstring, FindToken, IResult, InputIter,
+    AsBytes, Compare, CompareResult, Err, ExtendInto, FindSubstring, FindToken, IResult, InputIter,
     InputLength, InputTake, InputTakeAtPosition, Offset, ParseTo, Slice,
 };
 
@@ -536,7 +535,7 @@ impl<A: Compare<B>, B: Into<LocatedSpan<B>>, X> Compare<B> for LocatedSpan<A, X>
 }
 
 #[macro_export]
-#[deprecated]
+#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer needs a macro")]
 macro_rules! impl_compare {
     ( $fragment_type:ty, $compare_to_type:ty ) => {};
 }
@@ -724,7 +723,7 @@ macro_rules! impl_extend_into {
 
 #[cfg(feature = "std")]
 #[macro_export]
-#[deprecated]
+#[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer needs a macro")]
 macro_rules! impl_hex_display {
     ($fragment_type:ty) => {};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,17 +722,17 @@ macro_rules! impl_extend_into {
     };
 }
 
+#[cfg(feature = "alloc")]
+impl_extend_into!(&'a str, char, String);
+#[cfg(feature = "alloc")]
+impl_extend_into!(&'a [u8], u8, Vec<u8>);
+
 #[cfg(feature = "std")]
 #[macro_export]
 #[deprecated(since = "2.0.1", note = "this implementation has been generalized and no longer requires a macro")]
 macro_rules! impl_hex_display {
     ($fragment_type:ty) => {};
 }
-
-#[cfg(feature = "alloc")]
-impl_extend_into!(&'a str, char, String);
-#[cfg(feature = "alloc")]
-impl_extend_into!(&'a [u8], u8, Vec<u8>);
 
 /// Capture the position of the current fragment
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,53 +516,15 @@ impl_input_iter!(
     Map<Iter<'a, Self::Item>, fn(&u8) -> u8>
 );
 
-/// Implement nom::Compare for a specific fragment type.
-///
-/// # Parameters
-/// * `$fragment_type` - The LocatedSpan's `fragment` type
-/// * `$compare_to_type` - The type to be comparable to `LocatedSpan<$fragment_type, X>`
-///
-/// # Example of use
-///
-/// NB: This example is an extract from the nom_locate source code.
-///
-/// ````ignore
-/// #[macro_use]
-/// extern crate nom_locate;
-/// impl_compare!(&'b str, &'a str);
-/// impl_compare!(&'b [u8], &'a [u8]);
-/// impl_compare!(&'b [u8], &'a str);
-/// ````
-#[macro_export]
-macro_rules! impl_compare {
-    ( $fragment_type:ty, $compare_to_type:ty ) => {
-        impl<'a, 'b, X> Compare<$compare_to_type> for LocatedSpan<$fragment_type, X> {
-            #[inline(always)]
-            fn compare(&self, t: $compare_to_type) -> CompareResult {
-                self.fragment.compare(t)
-            }
-
-            #[inline(always)]
-            fn compare_no_case(&self, t: $compare_to_type) -> CompareResult {
-                self.fragment.compare_no_case(t)
-            }
-        }
-    };
-}
-
-impl_compare!(&'b str, &'a str);
-impl_compare!(&'b [u8], &'a [u8]);
-impl_compare!(&'b [u8], &'a str);
-
-impl<A: Compare<B>, B, X, Y> Compare<LocatedSpan<B, X>> for LocatedSpan<A, Y> {
+impl<A: Compare<B>, B: Into<LocatedSpan<B>>, Y> Compare<B> for LocatedSpan<A, Y> {
     #[inline(always)]
-    fn compare(&self, t: LocatedSpan<B, X>) -> CompareResult {
-        self.fragment.compare(t.fragment)
+    fn compare(&self, t: B) -> CompareResult {
+        self.fragment.compare(t.into().fragment)
     }
 
     #[inline(always)]
-    fn compare_no_case(&self, t: LocatedSpan<B, X>) -> CompareResult {
-        self.fragment.compare_no_case(t.fragment)
+    fn compare_no_case(&self, t: B) -> CompareResult {
+        self.fragment.compare_no_case(t.into().fragment)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -392,3 +392,25 @@ fn it_should_capture_position() {
     assert_eq!(s.line, 2);
     assert_eq!(t, "def");
 }
+
+#[test]
+fn it_should_deref_to_fragment() {
+    let input = &"foobar"[..];
+    assert_eq!(*StrSpanEx::new_extra(input, "extra"), input);
+    let input = &b"foobar"[..];
+    assert_eq!(*BytesSpanEx::new_extra(input, "extra"), input);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn it_should_display_hex() {
+    use nom::HexDisplay;
+    assert_eq!(
+        StrSpan::new(&"abc"[..]).to_hex(4),
+        "00000000\t61 62 63    \tabc\n".to_owned()
+    );
+    assert_eq!(
+        BytesSpanEx::new_extra(&b"abc"[..], "extra").to_hex(4),
+        "00000000\t61 62 63    \tabc\n".to_owned()
+    );
+}


### PR DESCRIPTION
There are three main changes in this PR:
 - [x] `Deref` trait implemented on `LocatedSpan`, pointing to `self.fragment` (see #7 comments)
 - [x] `Compare` generalized across all `LocatedSpan`
 - [x] `nom::HexDisplay` implementation removed in favor of nom's upstream implementation via dereference

Tests were added for dereferencing and hex dumps to prove that there was not a regression in removing the `nom::HexDisplay` implementation.

I suspect the `nom::ExtendInto` and `nom::Slice` implementations could still be generalized in the future, but I haven't been able to find the right combination of type constraints for those just yet.