### PR TITLE
impl StableDeref for LocatedSpan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ std = ["nom/std", "alloc"]
 alloc = ["nom/alloc"]
 generic-simd = ["bytecount/generic-simd"]
 runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
+stable-deref-trait = ["stable_deref_trait"]
 
 [dependencies]
 bytecount = "^0.6"
 memchr = ">=1.0.1, <3.0.0" # ^1.0.0 + ^2.0
 nom = { version = "5.0.0", default-features = false }
+stable_deref_trait = { version = "^1", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ use nom::{
     AsBytes, Compare, CompareResult, Err, FindSubstring, FindToken, IResult, InputIter,
     InputLength, InputTake, InputTakeAtPosition, Offset, ParseTo, Slice,
 };
+#[cfg(feature = "stable-deref-trait")]
+use stable_deref_trait::StableDeref;
 
 /// A LocatedSpan is a set of meta information about the location of a token, including extra
 /// information.
@@ -145,6 +147,14 @@ impl<T, X> core::ops::Deref for LocatedSpan<T, X> {
         &self.fragment
     }
 }
+
+#[cfg(feature = "stable-deref-trait")]
+/// Optionally impl StableDeref so that this type works harmoniously with other
+/// crates that rely on this marker trait, such as `rental` and `lazy_static`.
+/// LocatedSpan is largely just a wrapper around the contained type `T`, so
+/// this marker trait is safe to implement whenever T already implements
+/// StableDeref.
+unsafe impl<T: StableDeref, X> StableDeref for LocatedSpan<T, X> {}
 
 impl<T: AsBytes> LocatedSpan<T, ()> {
     /// Create a span for a particular input with default `offset` and


### PR DESCRIPTION
I can't implement this marker trait in my own code due to the orphan rule, and it's a [very broadly used](https://crates.io/crates/stable_deref_trait) marker trait and should be safe to implement here. The added dependency doesn't have any transitive dependencies and only contains the trait definitions + simple marker impls.