### PR TITLE
Generalize FindSubstring impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,12 +718,12 @@ impl<Fragment: FindToken<Token>, Token, X> FindToken<Token> for LocatedSpan<Frag
     }
 }
 
-impl<'a, T, X> FindSubstring<&'a str> for LocatedSpan<T, X>
+impl<T, U, X> FindSubstring<U> for LocatedSpan<T, X>
 where
-    T: FindSubstring<&'a str>,
+    T: FindSubstring<U>
 {
     #[inline]
-    fn find_substring(&self, substr: &'a str) -> Option<usize> {
+    fn find_substring(&self, substr: U) -> Option<usize> {
         self.fragment.find_substring(substr)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -281,6 +281,8 @@ fn it_should_find_substring() {
     assert_eq!(StrSpan::new("foobar").find_substring("baz"), None);
     assert_eq!(BytesSpan::new(b"foobar").find_substring("bar"), Some(3));
     assert_eq!(BytesSpan::new(b"foobar").find_substring("baz"), None);
+    assert_eq!(BytesSpan::new(b"foobar").find_substring(b"bar" as &[u8]), Some(3));
+    assert_eq!(BytesSpan::new(b"foobar").find_substring(b"baz" as &[u8]), None);
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Fixes `find_substring` with a byte slice on a byte slice backed `LocatedSpan`.