### PR TITLE
Update Display implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,9 +672,9 @@ impl<T, X> Offset for LocatedSpan<T, X> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: ToString, X> Display for LocatedSpan<T, X> {
+impl<T: Display, X> Display for LocatedSpan<T, X> {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
-        fmt.write_str(&self.fragment.to_string())
+        write!(fmt, "{}", self.fragment)
     }
 }
 


### PR DESCRIPTION
Removes possible allocation, removing to_string.

Maybe this is not allowed, as it is a possible breaking change, as every `T: Display` implements `ToString` but not the other way around.

I thought it may be positive to note that the old implementation allocated when not needed, like when `LocatedSpan<&str>` is used