### PR TITLE
Remove unneeded bounds & add map method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl<T, X> core::ops::Deref for LocatedSpan<T, X> {
 /// StableDeref.
 unsafe impl<T: StableDeref, X> StableDeref for LocatedSpan<T, X> {}
 
-impl<T: AsBytes> LocatedSpan<T, ()> {
+impl<T> LocatedSpan<T, ()> {
     /// Create a span for a particular input with default `offset` and
     /// `line` values and empty extra data.
     /// You can compute the column through the `get_column` or `get_utf8_column`
@@ -195,7 +195,7 @@ impl<T: AsBytes> LocatedSpan<T, ()> {
     }
 }
 
-impl<T: AsBytes, X> LocatedSpan<T, X> {
+impl<T, X> LocatedSpan<T, X> {
     /// Create a span for a particular input with default `offset` and
     /// `line` values. You can compute the column through the `get_column` or `get_utf8_column`
     /// methods.
@@ -267,7 +267,9 @@ impl<T: AsBytes, X> LocatedSpan<T, X> {
     pub fn fragment(&self) -> &T {
         &self.fragment
     }
+}
 
+impl<T: AsBytes, X> LocatedSpan<T, X> {
     // Attempt to get the "original" data slice back, by extending
     // self.fragment backwards by self.offset.
     // Note that any bytes truncated from after self.fragment will not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ impl<T, X> LocatedSpan<T, X> {
     ///                             |x| x.fragment().parse::<u8>().map(|n| x.map(|_| n))
     ///                         )
     ///                       ))(span).unwrap();
-    ///     assert_eq!(*n.fragment(), 10);
+    ///     assert_eq!(n.extra, 10);
     /// }
     /// ```
     pub fn map<U, F: Fn(X) -> U>(self, f: F) -> LocatedSpan<T, U> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,18 +277,15 @@ impl<T, X> LocatedSpan<T, X> {
     /// # use nom_locate::LocatedSpan;
     /// use nom::{
     ///   IResult,
-    ///   multi::{many0, many1},
     ///   combinator::{recognize, map_res},
     ///   sequence::{terminated, tuple},
-    ///   character::complete::{char, one_of},
-    ///   bytes::complete::tag
+    ///   character::{complete::{char, one_of}, is_digit},
+    ///   bytes::complete::{tag, take_while1}
     /// };
     ///
     /// fn decimal(input: LocatedSpan<&str>) -> IResult<LocatedSpan<&str>, LocatedSpan<&str>> {
     ///   recognize(
-    ///     many1(
-    ///       terminated(one_of("0123456789"), many0(char('_')))
-    ///     )
+    ///        take_while1(|c| is_digit(c as u8) || c == '_')
     ///   )(input)
     /// }
     ///
@@ -300,13 +297,13 @@ impl<T, X> LocatedSpan<T, X> {
     ///                         tag("$"),
     ///                         map_res(
     ///                             decimal,
-    ///                             |x| x.fragment().parse::<u8>().map(|n| x.map(|_| n))
+    ///                             |x| x.fragment().parse::<u8>().map(|n| x.map_extra(|_| n))
     ///                         )
     ///                       ))(span).unwrap();
     ///     assert_eq!(n.extra, 10);
     /// }
     /// ```
-    pub fn map<U, F: Fn(X) -> U>(self, f: F) -> LocatedSpan<T, U> {
+    pub fn map_extra<U, F: FnOnce(X) -> U>(self, f: F) -> LocatedSpan<T, U> {
         LocatedSpan {
             offset: self.offset,
             line: self.line,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ impl<T, X> LocatedSpan<T, X> {
         &self.fragment
     }
 
-    /// Transform the fragment inside into another type
+    /// Transform the extra inside into another type
     ///
     /// # Example of use
     /// ```
@@ -306,12 +306,12 @@ impl<T, X> LocatedSpan<T, X> {
     ///     assert_eq!(*n.fragment(), 10);
     /// }
     /// ```
-    pub fn map<U, F: Fn(T) -> U>(self, f: F) -> LocatedSpan<U, X> {
+    pub fn map<U, F: Fn(X) -> U>(self, f: F) -> LocatedSpan<T, U> {
         LocatedSpan {
             offset: self.offset,
             line: self.line,
-            fragment: f(self.fragment),
-            extra: self.extra,
+            fragment: self.fragment,
+            extra: f(self.extra),
         }
     }
 }


### PR DESCRIPTION
There are 2 commits on this PR:
 * f27b87f7d6090d1d5f688e5ba732eee9778c1b9a Remove bounds on some methods:
  Removes the `T: AsBytes` for the methods `new`, `new_extra`, `new_from_raw_offset`, `location_offset`, `location_line` and `fragment`.
 * 560c8f6246f9279a35a87446af0b28c9cd43a3e7 Add map method:
  Adds the method `map` to `LocatedSpan<T,X>`, which is like the `map` in iterators, but applied to the fragment. (Removed)
 * a95a58b Move the map method to use the `extra` field, as it is more useful, as there's no way to update the extra field without using unsafe or forgeting span location