### PR TITLE
Implement AsRef for LocatedSpan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,18 @@ impl<T, X> core::ops::Deref for LocatedSpan<T, X> {
     }
 }
 
+impl<T, X> core::convert::AsRef<T> for LocatedSpan<T, X> {
+    fn as_ref(&self) -> &T {
+        &self.fragment
+    }
+}
+
+impl<T: AsRef<[u8]>, X> core::convert::AsRef<[u8]> for LocatedSpan<T, X> {
+    fn as_ref(&self) -> &[u8] {
+        &self.fragment.as_ref()
+    }
+}
+
 #[cfg(feature = "stable-deref-trait")]
 /// Optionally impl StableDeref so that this type works harmoniously with other
 /// crates that rely on this marker trait, such as `rental` and `lazy_static`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,15 +149,13 @@ impl<T, X> core::ops::Deref for LocatedSpan<T, X> {
     }
 }
 
-impl<T, X> core::convert::AsRef<T> for LocatedSpan<T, X> {
-    fn as_ref(&self) -> &T {
-        &self.fragment
-    }
-}
-
-impl<T: AsRef<[u8]>, X> core::convert::AsRef<[u8]> for LocatedSpan<T, X> {
-    fn as_ref(&self) -> &[u8] {
-        &self.fragment.as_ref()
+impl<T, U, X> core::convert::AsRef<U> for LocatedSpan<&T, X>
+where
+    T: ?Sized + core::convert::AsRef<U>,
+    U: ?Sized,
+{
+    fn as_ref(&self) -> &U {
+        self.fragment.as_ref()
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -550,3 +550,30 @@ fn line_for_non_ascii_chars() {
        \n                     ^- The match\n",
     );
 }
+
+#[test]
+fn it_should_implement_as_ref_for_the_underlying_type() {
+    // LocatedSpan<&str> should implement AsRef<str>.
+    {
+        fn function_accepting_str<S: AsRef<str>>(_s: S) {}
+        let str_data = StrSpan::new("some data");
+        function_accepting_str(str_data);
+    }
+
+    // LocatedSpan<&[u8]> should implement AsRef<[u8]>.
+    {
+        fn function_accepting_u8_slice<B: AsRef<[u8]>>(_data: B) {}
+        let bytes_data = BytesSpan::new(b"some binary data");
+        function_accepting_u8_slice(bytes_data);
+    }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn it_should_implement_as_ref_impls_for_the_underlying_type() {
+    // Since str implements AsRef<Path>, it's useful to have LocatedSpan<&str>
+    // implement AsRef<Path> as well.
+    fn function_accepting_path<P: AsRef<std::path::Path>>(_path: P) {}
+    let str_data = StrSpan::new("some data");
+    function_accepting_path(str_data);
+}


### PR DESCRIPTION
Implement `AsRef<T>` for `LocatedSpan<T, X>` and `AsRef<[u8]>` for `LocatedSpan<T: AsRef<[u8]>, X>`. This makes it usable directly, e.g. in contexts expecting an `AsRef<Path>` or `AsRef<[u8]>`.