### PR TITLE
Bump minimum supported Rust version to 1.63.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  RUST_MINVERSION: 1.48.0
+  RUST_MINVERSION: 1.63.0
 
 jobs:
   test:
@@ -16,7 +16,7 @@ jobs:
         - stable
         - beta
         - nightly
-        - 1.48.0
+        - 1.63.0
 
         features:
         - ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 repository = "https://github.com/fflorent/nom_locate"
 version = "4.2.0"
 edition = "2018"
+rust-version = "1.63.0"
 
 [badges.travis-ci]
 repository = "fflorent/nom_locate"


### PR DESCRIPTION
Trying to compile on v1.48.0 now fails with:

```
Error: failed to parse manifest at `/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/memchr-2.6.4/Cargo.toml`
Caused by:
  failed to parse the `edition` key
```